### PR TITLE
Add async scraping web interface

### DIFF
--- a/async_web_app.py
+++ b/async_web_app.py
@@ -1,0 +1,78 @@
+import csv
+import uuid
+from pathlib import Path
+from typing import Dict, Any, Set
+
+from fastapi import FastAPI, UploadFile, File, BackgroundTasks
+from fastapi.responses import HTMLResponse, FileResponse
+from fastapi.templating import Jinja2Templates
+from fastapi import Request
+
+from scraper_utils import extract_sirens_from_csv, scrape_sirens, FIELDNAMES
+
+
+templates = Jinja2Templates(directory="templates")
+
+app = FastAPI()
+
+# In-memory job store
+jobs: Dict[str, Dict[str, Any]] = {}
+
+
+def extract_sirens_from_csv_file(path: Path) -> Set[str]:
+    """Extract SIREN numbers from a CSV file path."""
+    with path.open("r", encoding="utf-8", newline="") as f:
+        return extract_sirens_from_csv(f)
+
+
+def scrape_and_save(job_id: str, csv_path: Path, sleep: float = 0.5, threads: int = 4) -> None:
+    try:
+        sirens = extract_sirens_from_csv_file(csv_path)
+        results = scrape_sirens(sirens, sleep, threads)
+        output_path = csv_path.with_suffix(".out.csv")
+        with output_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+            writer.writeheader()
+            for row in results:
+                writer.writerow(row)
+        jobs[job_id]["status"] = "completed"
+        jobs[job_id]["result"] = str(output_path)
+    except Exception as e:
+        jobs[job_id]["status"] = f"error: {e}"
+    finally:
+        if csv_path.exists():
+            csv_path.unlink()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request, "jobs": jobs})
+
+
+@app.post("/upload")
+async def upload(background_tasks: BackgroundTasks, file: UploadFile = File(...)):
+    job_id = str(uuid.uuid4())
+    temp_path = Path(f"uploads/{job_id}.csv")
+    temp_path.parent.mkdir(exist_ok=True)
+    with temp_path.open("wb") as f:
+        content = await file.read()
+        f.write(content)
+    jobs[job_id] = {"status": "processing"}
+    background_tasks.add_task(scrape_and_save, job_id, temp_path)
+    return {"job_id": job_id}
+
+
+@app.get("/status/{job_id}")
+async def status(job_id: str):
+    job = jobs.get(job_id)
+    if not job:
+        return {"error": "job not found"}
+    return {"job_id": job_id, "status": job.get("status")}
+
+
+@app.get("/download/{job_id}")
+async def download(job_id: str):
+    job = jobs.get(job_id)
+    if not job or job.get("status") != "completed":
+        return {"error": "job not finished"}
+    return FileResponse(job["result"], media_type="text/csv", filename="results.csv")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ requests
 beautifulsoup4
 tqdm
 flask
+fastapi
+uvicorn
+python-multipart

--- a/scraper_utils.py
+++ b/scraper_utils.py
@@ -1,0 +1,57 @@
+import csv
+from io import TextIOWrapper
+from typing import Set, Dict, Any
+
+import requests
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import scrape_pappers
+
+
+def extract_sirens_from_csv(file_stream) -> Set[str]:
+    """Extract unique SIREN numbers from an uploaded CSV file."""
+    reader = csv.DictReader(TextIOWrapper(file_stream, encoding='utf-8'))
+    sirens: Set[str] = set()
+    known_cols = {'siren', 'siret', 'registration_number'}
+    for row in reader:
+        found = False
+        for col in known_cols:
+            val = row.get(col)
+            if val:
+                digits = ''.join(ch for ch in str(val) if ch.isdigit())
+                if len(digits) >= 9:
+                    sirens.add(digits[:9])
+                    found = True
+        if not found:
+            for val in row.values():
+                if not val:
+                    continue
+                digits = ''.join(ch for ch in str(val) if ch.isdigit())
+                if len(digits) >= 9:
+                    sirens.add(digits[:9])
+                    break
+    return sirens
+
+
+def scrape_sirens(sirens: Set[str], sleep: float = 0.5, threads: int = 4) -> list[Dict[str, Any]]:
+    results: list[Dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=threads) as pool:
+        futures = {pool.submit(scrape_pappers.scrape_siren, requests.Session(), s, sleep): s for s in sirens}
+        for future in as_completed(futures):
+            data = future.result()
+            if data:
+                results.append(data)
+    return results
+
+
+FIELDNAMES = [
+    "siren",
+    "denomination",
+    "forme_juridique",
+    "date_creation",
+    "capital",
+    "effectif",
+    "naf_code",
+    "adresse_siege",
+    "dirigeants",
+]

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <title>Pappers Async Scraper</title>
+</head>
+<body>
+    <h1>Upload CSV for Async Scraping</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="file" required>
+        <input type="submit" value="Upload">
+    </form>
+
+    <h2>Jobs</h2>
+    <ul>
+        {% for job_id, info in jobs.items() %}
+            <li>
+                {{ job_id }} - {{ info['status'] }}
+                {% if info['status'] == 'completed' %}
+                    - <a href="/download/{{ job_id }}">Download</a>
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,62 +1,13 @@
 import csv
-from io import StringIO, TextIOWrapper
+from io import StringIO
 from typing import Set, Dict, Any
 
 from flask import Flask, request, send_file, render_template_string
 
 import requests
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import scrape_pappers
-
-
-def extract_sirens_from_csv(file_stream) -> Set[str]:
-    """Extract unique SIREN numbers from an uploaded CSV file."""
-    reader = csv.DictReader(TextIOWrapper(file_stream, encoding='utf-8'))
-    sirens: Set[str] = set()
-    known_cols = {'siren', 'siret', 'registration_number'}
-    for row in reader:
-        found = False
-        for col in known_cols:
-            val = row.get(col)
-            if val:
-                digits = ''.join(ch for ch in str(val) if ch.isdigit())
-                if len(digits) >= 9:
-                    sirens.add(digits[:9])
-                    found = True
-        if not found:
-            for val in row.values():
-                if not val:
-                    continue
-                digits = ''.join(ch for ch in str(val) if ch.isdigit())
-                if len(digits) >= 9:
-                    sirens.add(digits[:9])
-                    break
-    return sirens
-
-
-def scrape_sirens(sirens: Set[str], sleep: float = 0.5, threads: int = 4) -> list[Dict[str, Any]]:
-    results: list[Dict[str, Any]] = []
-    with ThreadPoolExecutor(max_workers=threads) as pool:
-        futures = {pool.submit(scrape_pappers.scrape_siren, requests.Session(), s, sleep): s for s in sirens}
-        for future in as_completed(futures):
-            data = future.result()
-            if data:
-                results.append(data)
-    return results
-
-
-FIELDNAMES = [
-    "siren",
-    "denomination",
-    "forme_juridique",
-    "date_creation",
-    "capital",
-    "effectif",
-    "naf_code",
-    "adresse_siege",
-    "dirigeants",
-]
+from scraper_utils import extract_sirens_from_csv, scrape_sirens, FIELDNAMES
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- add async FastAPI app for background scraping jobs
- move CSV utilities into `scraper_utils.py`
- update Flask app to use shared utilities
- create simple HTML template
- update dependencies

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile scrape_pappers.py web_app.py async_web_app.py scraper_utils.py`
- `python async_web_app.py` *(started successfully and exited)*

------
https://chatgpt.com/codex/tasks/task_e_68838b0f80e88333877eb84a8866fd6c