### PR TITLE
Add Pyth WebSocket price client and in-memory monitor

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -1,0 +1,21 @@
+"""Monitor profit using in-memory price store instead of HTTP requests."""
+
+import time
+from price_stream import PriceStore
+
+
+price_store = PriceStore()
+
+
+def monitor_profit_and_sell(mint: str, entry_price: float, target_profit: float) -> None:
+    """Check in-memory price and trigger a sell on target profit."""
+    while True:
+        current = price_store.get_price(mint)
+        if current is None:
+            time.sleep(1)
+            continue
+        profit = (current - entry_price) / entry_price
+        if profit >= target_profit:
+            print(f"Selling {mint} at {current} with profit {profit:.2%}")
+            break
+        time.sleep(1)

--- a/price_stream.py
+++ b/price_stream.py
@@ -1,0 +1,39 @@
+"""WebSocket price client using Pyth network."""
+
+import asyncio
+import json
+from typing import Dict
+
+import websockets
+
+
+class PriceStore:
+    """In-memory store for latest prices keyed by mint/ID."""
+
+    def __init__(self) -> None:
+        self._prices: Dict[str, float] = {}
+
+    def update_price(self, mint: str, price: float) -> None:
+        self._prices[mint] = price
+
+    def get_price(self, mint: str) -> float | None:
+        return self._prices.get(mint)
+
+
+class PythPriceClient:
+    """Subscribe to Pyth price feed and update the store."""
+
+    def __init__(self, price_id: str, store: PriceStore) -> None:
+        self.price_id = price_id
+        self.store = store
+        self.url = "wss://hermes.pyth.network/ws"
+
+    async def run(self) -> None:
+        async with websockets.connect(self.url) as ws:
+            subscribe_msg = {"type": "subscribe", "ids": [self.price_id]}
+            await ws.send(json.dumps(subscribe_msg))
+            async for raw in ws:
+                data = json.loads(raw)
+                price = data.get("price")
+                if price is not None:
+                    self.store.update_price(self.price_id, price)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flask
 fastapi
 uvicorn
 python-multipart
+websockets


### PR DESCRIPTION
## Summary
- add Pyth WebSocket price client with PriceStore
- add monitor_profit_and_sell using in-memory price
- include websockets dependency

## Testing
- `python -m py_compile price_stream.py monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0686998ac83339fb287437369b18e